### PR TITLE
Optimize AttributeAnnotations for speed.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,16 @@ Changes
 4.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Optimize ``AttributeAnnotations`` for speed. In the case that only
+  one method is called on a given instance, there should be no
+  difference. But if more than one method is called, there should be a
+  speed increase (such as the common pattern ``if 'key' not in
+  annotations: annotations['key'] = value``). A consequence is that
+  read-only operations on a given AttributeAnnotations instance will
+  not immediately reflect changes made to other extant
+  ``AttributeAnnotations`` objects, *if* the
+  underlying object had no annotations to begin with. See `issue 8
+  <https://github.com/zopefoundation/zope.annotation/issues/8>`_.
 
 
 4.5 (2017-06-03)

--- a/src/zope/annotation/attribute.py
+++ b/src/zope/annotation/attribute.py
@@ -39,47 +39,46 @@ class AttributeAnnotations(DictMixin):
 
     def __init__(self, obj, context=None):
         self.obj = obj
+        self._annotations = getattr(obj, '__annotations__', _EMPTY_STORAGE)
 
     def __bool__(self):
-        return bool(getattr(self.obj, '__annotations__', 0))
+        return bool(self._annotations)
 
     __nonzero__ = __bool__
 
     def get(self, key, default=None):
         """See zope.annotation.interfaces.IAnnotations"""
-        annotations = getattr(self.obj, '__annotations__', _EMPTY_STORAGE)
-        return annotations.get(key, default)
+        return self._annotations.get(key, default)
 
     def __getitem__(self, key):
-        annotations = getattr(self.obj, '__annotations__', _EMPTY_STORAGE)
-        return annotations[key]
+        return self._annotations[key]
 
     def keys(self):
-        annotations = getattr(self.obj, '__annotations__', _EMPTY_STORAGE)
-        return annotations.keys()
+        return self._annotations.keys()
 
     def __iter__(self):
-        annotations = getattr(self.obj, '__annotations__', _EMPTY_STORAGE)
-        return iter(annotations)
+        return iter(self._annotations)
 
     def __len__(self):
-        annotations = getattr(self.obj, '__annotations__', _EMPTY_STORAGE)
-        return len(annotations)
+        return len(self._annotations)
+
+    # Writing must refresh the attribute from the underlying object,
+    # in case of modification by a different AttributeAnnotations object.
 
     def __setitem__(self, key, value):
         """See zope.annotation.interfaces.IAnnotations"""
         try:
-            annotations = self.obj.__annotations__
+            self._annotations = self.obj.__annotations__
         except AttributeError:
-            annotations = self.obj.__annotations__ = _STORAGE()
+            self._annotations = self.obj.__annotations__ = _STORAGE()
 
-        annotations[key] = value
+        self._annotations[key] = value
 
     def __delitem__(self, key):
         """See zope.app.interfaces.annotation.IAnnotations"""
         try:
-            annotation = self.obj.__annotations__
+            self._annotations = self.obj.__annotations__
         except AttributeError:
             raise KeyError(key)
 
-        del annotation[key]
+        del self._annotations[key]

--- a/src/zope/annotation/interfaces.py
+++ b/src/zope/annotation/interfaces.py
@@ -94,7 +94,7 @@ class IAnnotations(IAnnotatable):
 
 class IAttributeAnnotatable(IAnnotatable):
     """Marker indicating that annotations can be stored on an attribute.
-    
+
     This is a marker interface giving permission for an `IAnnotations`
     adapter to store data in an attribute named `__annotations__`.
 

--- a/src/zope/annotation/tests/annotations.py
+++ b/src/zope/annotation/tests/annotations.py
@@ -19,7 +19,7 @@ used as base tests for real implementations.
 from zope.interface.verify import verifyObject
 from zope.annotation.interfaces import IAnnotations
 
-class AnnotationsTestBase(object):
+class AnnotationsTestBaseMixin(object):
     """Test the IAnnotations interface.
 
     The test case class expects the 'IAnnotations' implementer to be in

--- a/src/zope/annotation/tests/test_attributeannotations.py
+++ b/src/zope/annotation/tests/test_attributeannotations.py
@@ -13,15 +13,16 @@
 ##############################################################################
 import unittest
 
-from zope.annotation.tests.annotations import AnnotationsTestBase
+from zope.testing import cleanup
+from zope.interface import implementer
+from zope.annotation.attribute import AttributeAnnotations
+from zope.annotation.interfaces import IAttributeAnnotatable
 
-class AttributeAnnotationsTest(AnnotationsTestBase, unittest.TestCase):
+from zope.annotation.tests.annotations import AnnotationsTestBaseMixin
+
+class AttributeAnnotationsTest(AnnotationsTestBaseMixin, unittest.TestCase):
 
     def setUp(self):
-        from zope.testing import cleanup
-        from zope.interface import implementer
-        from zope.annotation.attribute import AttributeAnnotations
-        from zope.annotation.interfaces import IAttributeAnnotatable
 
         cleanup.setUp()
 
@@ -32,9 +33,67 @@ class AttributeAnnotationsTest(AnnotationsTestBase, unittest.TestCase):
         self.obj = Dummy()
         self.annotations = AttributeAnnotations(self.obj)
 
-    def tearDown(test=None):
-        from zope.testing import cleanup
+    def tearDown(self):
         cleanup.tearDown()
+
+    def test_two_annotations_same_obj_set(self):
+        annotations2 = AttributeAnnotations(self.obj)
+
+        # Initially both are empty
+        self.assertFalse(self.annotations)
+        self.assertFalse(annotations2)
+
+        # Adding a key is initially only visible in the direct object
+        self.annotations['key'] = 42
+        self.assertIn('key', self.annotations)
+        self.assertNotIn('key', annotations2)
+
+        self.annotations['key2'] = 43
+        self.assertIn('key2', self.annotations)
+        self.assertNotIn('key2', annotations2)
+
+        # But manipulating the alternate object via adding an item
+        # refreshes the annotations
+        annotations2['key3'] = 44
+        self.assertIn('key', self.annotations)
+        self.assertIn('key', annotations2)
+        self.assertIn('key2', self.annotations)
+        self.assertIn('key2', annotations2)
+        self.assertIn('key3', self.annotations)
+        self.assertIn('key3', annotations2)
+
+    def test_two_annotations_same_obj_del(self):
+        annotations2 = AttributeAnnotations(self.obj)
+
+        # Initially both are empty
+        self.assertFalse(self.annotations)
+        self.assertFalse(annotations2)
+
+        # Adding a key is initially only visible in the direct object
+        self.annotations['key'] = 42
+        self.assertIn('key', self.annotations)
+        self.assertNotIn('key', annotations2)
+
+        self.annotations['key2'] = 43
+        self.assertIn('key2', self.annotations)
+        self.assertNotIn('key2', annotations2)
+
+        # But manipulating the alternate object via deleting an item
+        # refreshes the annotations
+        del annotations2['key']
+        self.assertNotIn('key', self.annotations)
+        self.assertNotIn('key', annotations2)
+        self.assertIn('key2', self.annotations)
+        self.assertIn('key2', annotations2)
+
+    def test_two_annotations_same_obj_create_after_modify(self):
+        self.annotations['key'] = 42
+
+        # Creating a new attribute annotations at this time recognizes
+        # the key
+        annotations2 = AttributeAnnotations(self.obj)
+        self.assertIn('key', annotations2)
+        self.assertEqual(42, annotations2['key'])
 
 
 def test_suite():


### PR DESCRIPTION
Fixes #8.

See that issue and the change note for a consequence.

I like that the code is cleaner (DRY) and I like that repeated operations are faster. However, I'm not sure whether or not the consequence (altering views of an object that initially had no annotations, but then an annotation is added to an instance of AttributeAnnotations, but then queried for on a different existing AttributeAnnotations) is worth it.