### PR TITLE
Make AttributeAnnotations have a __parent__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changes
 4.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Make ``AttributeAnnotations`` have a ``__parent__``. The
+  ``__parent__`` is the object that it stores ``__annotations__`` on.
+  This is a convenience for upwards traversal as used by things like
+  ``zope.keyreference``. See
+  https://github.com/zopefoundation/zope.annotation/issues/11
 
 
 4.5 (2017-06-03)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,10 +10,6 @@ These interfaces define the source and targets for adaptation under the
 
 .. automodule:: zope.annotation.interfaces
 
-   .. autointerface::  IAnnotatable
-
-   .. autointerface::  IAnnotations
-
 
 Attribute-Based Annotations
 ---------------------------
@@ -25,6 +21,9 @@ The default adapter implementation uses a special attribute,
 
 Because setting an attribute is somewhat intrusive (as opposed to storing
 annotations elsewhere), this adapter requires that its context implment
-``IAttributeAnnotatable`` to signal that this attribute can be used.
+:class:`zope.annotation.interfaces.IAttributeAnnotatable` to signal that this attribute can be used.
 
-.. autointerface::  zope.annotation.interfaces.IAttributeAnnotatable
+Factories
+---------
+
+.. automodule:: zope.annotation.factory

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -252,3 +252,10 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
+
+autodoc_default_flags = [
+    'members',
+    'show-inheritance',
+]
+autoclass_content = 'both'
+autodoc_member_order = 'bysource'

--- a/docs/narrative.rst
+++ b/docs/narrative.rst
@@ -53,10 +53,10 @@ Now let's create an annotation for this:
    ...         self.b = 2
 
 Note that the annotation implementation does not expect any arguments
-to its `__init__`. Otherwise it's basically an adapter.
+to its ``__init__``. Otherwise it's basically an adapter.
 
 Now, we'll register the annotation as an adapter. To do this we use
-the `factory` function provided by `zope.annotation`:
+the :func:`~.factory` function provided by ``zope.annotation``:
 
 .. doctest::
 
@@ -70,7 +70,7 @@ the `factory` function provided by `zope.annotation`:
 Note that we do not need to specify what the adapter provides or what
 it adapts - we already do this on the annotation class itself.
 
-Now let's make an instance of `Foo`, and make an annotation for it.
+Now let's make an instance of ``Foo``, and make an annotation for it.
 
 .. doctest::
 
@@ -81,7 +81,7 @@ Now let's make an instance of `Foo`, and make an annotation for it.
    >>> bar.b
    2
 
-We'll change `a` and get the annotation again. Our change is still
+We'll change ``a`` and get the annotation again. Our change is still
 there:
 
 .. doctest::
@@ -90,7 +90,7 @@ there:
    >>> IBar(foo).a
    3
 
-Of course it's still different for another instance of `Foo`:
+Of course it's still different for another instance of ``Foo``:
 
 .. doctest::
 

--- a/src/zope/annotation/attribute.py
+++ b/src/zope/annotation/attribute.py
@@ -13,6 +13,7 @@
 ##############################################################################
 """Attribute Annotations implementation"""
 import logging
+from collections import MutableMapping as DictMixin
 
 try:
     from BTrees.OOBTree import OOBTree as _STORAGE
@@ -24,7 +25,6 @@ except ImportError: # pragma: no cover
 from zope import component, interface
 from zope.annotation import interfaces
 
-from collections import MutableMapping as DictMixin
 
 _EMPTY_STORAGE = _STORAGE()
 
@@ -47,6 +47,10 @@ class AttributeAnnotations(DictMixin):
 
     def __init__(self, obj, context=None):
         self.obj = obj
+
+    @property
+    def __parent__(self):
+        return self.obj
 
     def __bool__(self):
         return bool(getattr(self.obj, '__annotations__', 0))

--- a/src/zope/annotation/tests/test_attributeannotations.py
+++ b/src/zope/annotation/tests/test_attributeannotations.py
@@ -32,9 +32,13 @@ class AttributeAnnotationsTest(AnnotationsTestBase, unittest.TestCase):
         self.obj = Dummy()
         self.annotations = AttributeAnnotations(self.obj)
 
-    def tearDown(test=None):
+    def tearDown(self):
         from zope.testing import cleanup
         cleanup.tearDown()
+
+    def testInterfaceVerifies(self):
+        super(AttributeAnnotationsTest, self).testInterfaceVerifies()
+        self.assertIs(self.obj, self.annotations.__parent__)
 
 
 def test_suite():


### PR DESCRIPTION
Fixes #11 in a BWC way using a property. This makes it more like zope.principalannotation (though I didn't change the interface here).

Also some doc fixes I noticed when I was fixing up the doctest snippets (I originally had this implementing ``ILocation`` with a `__name__` of `__annotations__` but I realized that didn't really make any sense so I backed it out.)