### PR TITLE
Fix run coverage command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
 
 [testenv]
 commands =
-    coverage run -m zope.testrunner --test-path=src {posargs:-vc}
+    python -m coverage run -m zope.testrunner --test-path=src {posargs:-vc}
 deps =
     .[btrees,test]
     zope.testrunner


### PR DESCRIPTION
Linux distributions provides coverage script on their own way for
support python2 and python3 both together.
For example coverage with python2 shebang either with python3
one. Or scripts with another names, e.g. coverage - python2 shebang,
coverage3 - python3 shebang. Therefore it is better to import module
instead.